### PR TITLE
fix(python): pin Ruff formatter version

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -25,7 +25,9 @@ definition document {
 rel = Relationship(
     resource=ObjectReference(object_type="document", object_id="readme"),
     relation="reader",
-    subject=SubjectReference(object=ObjectReference(object_type="user", object_id="alice")),
+    subject=SubjectReference(
+        object=ObjectReference(object_type="user", object_id="alice")
+    ),
 )
 
 with EmbeddedSpiceDB.start(schema, [rel]) as spicedb:
@@ -33,10 +35,14 @@ with EmbeddedSpiceDB.start(schema, [rel]) as spicedb:
         consistency=Consistency(fully_consistent=True),
         resource=ObjectReference(object_type="document", object_id="readme"),
         permission="read",
-        subject=SubjectReference(object=ObjectReference(object_type="user", object_id="alice")),
+        subject=SubjectReference(
+            object=ObjectReference(object_type="user", object_id="alice")
+        ),
     )
     resp = spicedb.permissions().CheckPermission(req)
-    allowed = resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+    allowed = (
+        resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+    )
 ```
 
 ## Who should consider using this?
@@ -132,7 +138,9 @@ definition document {
 rel = Relationship(
     resource=ObjectReference(object_type="document", object_id="readme"),
     relation="reader",
-    subject=SubjectReference(object=ObjectReference(object_type="user", object_id="alice")),
+    subject=SubjectReference(
+        object=ObjectReference(object_type="user", object_id="alice")
+    ),
 )
 
 with EmbeddedSpiceDB.start(schema, [rel]) as spicedb:
@@ -141,10 +149,14 @@ with EmbeddedSpiceDB.start(schema, [rel]) as spicedb:
         consistency=Consistency(fully_consistent=True),
         resource=ObjectReference(object_type="document", object_id="readme"),
         permission="read",
-        subject=SubjectReference(object=ObjectReference(object_type="user", object_id="alice")),
+        subject=SubjectReference(
+            object=ObjectReference(object_type="user", object_id="alice")
+        ),
     )
     resp = stub.CheckPermission(req)
-    allowed = resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+    allowed = (
+        resp.permissionship == CheckPermissionResponse.PERMISSIONSHIP_HAS_PERMISSION
+    )
 ```
 
 ## API

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -31,7 +31,7 @@ Repository = "https://github.com/borkfork/spicedb-embedded"
 Documentation = "https://github.com/borkfork/spicedb-embedded/tree/main/python"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0.0", "ruff>=0.8.0"]
+dev = ["pytest>=7.0.0", "ruff==0.16.0"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

Ruff was specified with a lower bound, so local environments could stay on 0.15 while fresh CI installed 0.16. Ruff 0.16 started formatting Python blocks inside Markdown, which is why [PR #160](https://github.com/borkfork/spicedb-embedded/pull/160) failed remotely while `mise run python-reformat` was clean locally.

This pins Ruff to 0.16.0 and includes the resulting formatting changes to `python/README.md`. We should now get the same formatting locally and in CI (a surprisingly useful property for a formatter).

## Test plan

- [x] `mise run python-reformat`
- [x] `mise run python-format-check`
- [x] Pre-commit formatting hooks
